### PR TITLE
Check invoice balance before rendering QR code in web view

### DIFF
--- a/application/views/invoice_templates/public/InvoicePlane_Web.php
+++ b/application/views/invoice_templates/public/InvoicePlane_Web.php
@@ -253,7 +253,7 @@
 
             <hr>
 
-            <?php if (get_setting('qr_code')) : ?>
+            <?php if (get_setting('qr_code') && $invoice->invoice_balance > 0) : ?>
                 <table class="invoice-qr-code-table">
                     <tr>
                         <td>


### PR DESCRIPTION
## Description
In the default invoice web template, if the invoice is paid, a PHP error is rendered in place of the QR code.
This happens because the invoice_qrcode() function expects a balance greater than or equal to 0.01, to use as the transaction amount in the QR data.

## Motivation and Context
This PR solves this issue by checking that the invoice balance is > 0 before rendering the QR code element
(similar to the default invoice PDF templates, where in the default paid template, there is no QR section).

## Pull Request Checklist

  * [x] My code follows the code formatting guidelines.
  * [ ] I have an issue ID for this pull request.
  * [x] I selected the corresponding branch.
  * [x] I have rebased my changes on top of the corresponding branch.

## Issue Type (Please check one or more)

  * [x] Bugfix
  * [ ] Improvement of an existing Feature
  * [ ] New Feature